### PR TITLE
Pass site to celery task from outside

### DIFF
--- a/openedx/features/qverse_features/registration/signals.py
+++ b/openedx/features/qverse_features/registration/signals.py
@@ -7,6 +7,7 @@ from django.db.models.signals import post_save
 from django.dispatch import receiver
 from django.utils.crypto import get_random_string
 
+from openedx.core.djangoapps.theming.helpers import get_current_site
 from openedx.features.qverse_features.registration.models import BulkUserRegistration, QVerseUserProfile, Department
 from openedx.features.qverse_features.registration.tasks import send_bulk_mail_to_newly_created_students
 from student.models import UserProfile
@@ -82,7 +83,10 @@ def create_users_from_csv_file(sender, instance, created, **kwargs):
     csv_file.close()
     _write_status_on_csv_file(instance.admission_file.path, output_file_rows)
     new_students = [student for student in output_file_rows if student.get('status') == USER_CREATED]
-    send_bulk_mail_to_newly_created_students.delay(new_students)
+    context = {
+        'site': get_current_site()
+    }
+    send_bulk_mail_to_newly_created_students.delay(new_students, context)
 
 
 def _create_or_update_edx_user(user_info):

--- a/openedx/features/qverse_features/registration/tasks.py
+++ b/openedx/features/qverse_features/registration/tasks.py
@@ -9,7 +9,6 @@ from edx_ace import ace
 from edx_ace.recipient import Recipient
 
 from openedx.core.djangoapps.ace_common.template_context import get_base_template_context
-from openedx.core.djangoapps.theming.helpers import get_current_site
 from openedx.core.lib.celery.task_utils import emulate_http_request
 from openedx.features.qverse_features.registration.message_types import RegistrationNotification
 
@@ -19,15 +18,16 @@ ACE_ROUTING_KEY = getattr(settings, 'ACE_ROUTING_KEY', None)
 
 
 @task(routing_key=ACE_ROUTING_KEY)
-def send_bulk_mail_to_newly_created_students(new_students):
+def send_bulk_mail_to_newly_created_students(new_students, context):
     """
     A celery task, responsible to send registration email to newly created users.
 
     Arguments:
         students (list): A list of dicts containing information about newly created
                          users
+        context (dict): A dict containing required values like site
     """
-    site = get_current_site()
+    site = context.get('site')
     context = get_base_template_context(site)
     context['site_name'] = site.domain
     for new_student in new_students:


### PR DESCRIPTION
This PR is related to [https://edlyio.atlassian.net/browse/EDE-343](https://edlyio.atlassian.net/browse/EDE-343)

**Description**

In celery task `get_current_site` method returns `None`. So, I am passing `Site` object from outside.