### PR TITLE
Pass site id instead of whole site object

### DIFF
--- a/openedx/features/qverse_features/registration/signals.py
+++ b/openedx/features/qverse_features/registration/signals.py
@@ -83,10 +83,8 @@ def create_users_from_csv_file(sender, instance, created, **kwargs):
     csv_file.close()
     _write_status_on_csv_file(instance.admission_file.path, output_file_rows)
     new_students = [student for student in output_file_rows if student.get('status') == USER_CREATED]
-    context = {
-        'site': get_current_site()
-    }
-    send_bulk_mail_to_newly_created_students.delay(new_students, context)
+    site = get_current_site()
+    send_bulk_mail_to_newly_created_students.delay(new_students, site.id)
 
 
 def _create_or_update_edx_user(user_info):

--- a/openedx/features/qverse_features/registration/tasks.py
+++ b/openedx/features/qverse_features/registration/tasks.py
@@ -5,6 +5,7 @@ from celery.task import task
 from celery.utils.log import get_task_logger
 from django.conf import settings
 from django.contrib.auth.models import User
+from django.contrib.sites.models import Site
 from edx_ace import ace
 from edx_ace.recipient import Recipient
 
@@ -18,16 +19,16 @@ ACE_ROUTING_KEY = getattr(settings, 'ACE_ROUTING_KEY', None)
 
 
 @task(routing_key=ACE_ROUTING_KEY)
-def send_bulk_mail_to_newly_created_students(new_students, context):
+def send_bulk_mail_to_newly_created_students(new_students, site_id):
     """
     A celery task, responsible to send registration email to newly created users.
 
     Arguments:
         students (list): A list of dicts containing information about newly created
                          users
-        context (dict): A dict containing required values like site
+        site_id (int): Current site id
     """
-    site = context.get('site')
+    site = Site.objects.get(id=site_id)
     context = get_base_template_context(site)
     context['site_name'] = site.domain
     for new_student in new_students:


### PR DESCRIPTION
This PR is related to [https://edlyio.atlassian.net/browse/EDE-343](https://edlyio.atlassian.net/browse/EDE-343)

**Description**

In celery task we can't pass django objects so now we are passing id of current site and then we will get it from db using that id in the task.