### PR TITLE
Umar/add unit tests for registration app

### DIFF
--- a/openedx/features/qverse_features/registration/models.py
+++ b/openedx/features/qverse_features/registration/models.py
@@ -101,7 +101,7 @@ class QVerseUserProfile(models.Model):
 
         This would help us to ensure unique constraint of registration number.
         """
-        self.registration_number = self.registration_number.title()
+        self.registration_number = self.registration_number.upper()
         return super(QVerseUserProfile, self).save(*args, **kwargs)
 
     def __str__(self):

--- a/openedx/features/qverse_features/registration/tests/factories.py
+++ b/openedx/features/qverse_features/registration/tests/factories.py
@@ -1,0 +1,39 @@
+"""
+Factories for QVerse registration app unit tests.
+"""
+import factory
+import factory.fuzzy
+import string
+
+from openedx.features.qverse_features.registration.models import (Department, QVerseUserProfile,
+                                                                  MAX_LEVEL_CHOICES, MAX_PROGRAMME_CHOICES)
+from student.tests.factories import UserFactory
+
+
+class DepartmentFactory(factory.django.DjangoModelFactory):
+    """
+    Creates department.
+    """
+    class Meta(object):
+        model = Department
+        django_get_or_create = ('name', 'number', )
+
+    name = factory.Sequence(u'Department_{0}'.format)
+    number = factory.Sequence(int)
+
+
+class QVerseUserProfileFactory(factory.django.DjangoModelFactory):
+    """
+    Creates QVerseUserProfile.
+    """
+    class Meta(object):
+        model = QVerseUserProfile
+        django_get_or_create = ('user', 'registration_number', )
+
+    user = factory.SubFactory(UserFactory)
+    department = factory.SubFactory(DepartmentFactory)
+    registration_number = factory.LazyAttribute(u'{0.user.username}'.format)
+    other_name = factory.Sequence(u'robot-{0}'.format)
+    mobile_number = factory.fuzzy.FuzzyText(length=11, chars=string.digits)
+    current_level = factory.fuzzy.FuzzyInteger(1, MAX_LEVEL_CHOICES)
+    programme = factory.fuzzy.FuzzyInteger(1, MAX_PROGRAMME_CHOICES)

--- a/openedx/features/qverse_features/registration/tests/fixtures/admission_file.csv
+++ b/openedx/features/qverse_features/registration/tests/fixtures/admission_file.csv
@@ -1,0 +1,6 @@
+surname,firstname,mobile,othername,programmeid,levelid,regno,email,departmentid
+Vincent,John,090078601,Micky,1,1,EMP1,emp1@example.com,1
+Alie,John,090078601,Jacky,1,1,EMP2,emp2@example.com,1
+Alie,John,090078601,Jacky,1,1,EMP2,emp2@example.com,1
+Alie,John,090078601,Jacky,1,1,EMP2
+Alie,John,090078601,Jacky,1,1,EMP2,emp9@example.com,1

--- a/openedx/features/qverse_features/registration/tests/fixtures/invalid_admission_file.csv
+++ b/openedx/features/qverse_features/registration/tests/fixtures/invalid_admission_file.csv
@@ -1,0 +1,2 @@
+CompanyName,EmployeeNumber,EmployeeName
+Google,EMP1,Martin

--- a/openedx/features/qverse_features/registration/tests/test_models.py
+++ b/openedx/features/qverse_features/registration/tests/test_models.py
@@ -1,0 +1,65 @@
+"""
+Unit tests for QVerse registration app models.
+"""
+import mock
+import os
+
+from django.contrib.auth.models import User
+from django.core.files.base import ContentFile
+from django.test import TestCase
+
+from openedx.features.qverse_features.registration.models import BulkUserRegistration, QVerseUserProfile
+from openedx.features.qverse_features.registration.tests.factories import DepartmentFactory, QVerseUserProfileFactory
+from student.models import UserProfile
+
+
+class BulkUserRegistrationTests(TestCase):
+    """
+    Tests for BulkUserRegistration model.
+    """
+    def setUp(self):
+        self.file_directory = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'fixtures')
+        DepartmentFactory(number=1)
+
+    @mock.patch(
+        'openedx.features.qverse_features.registration.signals.get_current_site',
+        autospec=True
+    )
+    @mock.patch(
+        'openedx.features.qverse_features.registration.signals.send_bulk_mail_to_newly_created_students.delay',
+        autospec=True
+    )
+    def test_bulk_user_registration_with_valid_admission_file(self, mocked_mail, mocked_site):
+        file_path = os.path.join(self.file_directory, 'admission_file.csv')
+        with open(file_path, 'r') as admission_file:
+            BulkUserRegistration.objects.create(admission_file=ContentFile(admission_file.read(), 'admission_file.csv'),
+                                                description='Testing Batch')
+
+            self.assertEqual(User.objects.all().count(), 2)
+            self.assertEqual(UserProfile.objects.all().count(), 2)
+            self.assertEqual(QVerseUserProfile.objects.all().count(), 2)
+            self.assertTrue(mocked_site.called)
+            self.assertTrue(mocked_mail.called)
+            self.assertEqual(str(BulkUserRegistration.objects.first()), 'Testing Batch')
+
+
+class DepartmentTests(TestCase):
+    """
+    Tests for Department model.
+    """
+    def setUp(self):
+        self.department = DepartmentFactory(number=1, name='Demo Department')
+
+    def test_department_string_representation(self):
+        self.assertEqual(str(self.department), '1: Demo Department')
+
+
+class QVerseUserProfileTests(TestCase):
+    """
+    Tests for QVerseUserProfile Model.
+    """
+    def setUp(self):
+        self.qverse_profile = QVerseUserProfileFactory()
+
+    def test_qverse_user_profile_string_representation(self):
+        self.assertEqual(str(self.qverse_profile), '(ROBOT0) --- Robot0 Test')

--- a/openedx/features/qverse_features/registration/tests/test_register.py
+++ b/openedx/features/qverse_features/registration/tests/test_register.py
@@ -1,0 +1,81 @@
+"""
+Tests for account creation.
+"""
+from ddt import ddt, data
+
+from django.conf import settings
+from django.contrib.auth.models import User
+from django.test import TestCase
+from django.test.utils import override_settings
+from django.urls import reverse
+
+from openedx.features.qverse_features.registration.models import (QVerseUserProfile,
+                                                                  MAX_LEVEL_CHOICES,
+                                                                  MAX_PROGRAMME_CHOICES)
+from openedx.features.qverse_features.registration.tests.factories import DepartmentFactory
+
+from student.models import UserProfile
+
+OVERRIDDEN_FEATURES = settings.FEATURES.copy()
+OVERRIDDEN_FEATURES['ENABLE_COMBINED_LOGIN_REGISTRATION'] = True
+
+
+@ddt
+@override_settings(
+    REGISTRATION_EXTENSION_FORM='openedx.features.qverse_features.registration.forms.QVerseUserProfileForm',
+    FEATURES=OVERRIDDEN_FEATURES
+)
+class CreateAccountTests(TestCase):
+    """
+    Tests for account creation.
+    """
+    def setUp(self):
+        super(CreateAccountTests, self).setUp()
+        DepartmentFactory(number=1)
+        self.username = 'test_user'
+        self.url = reverse('create_account')
+        self.params = {
+            'username': self.username,
+            'email': 'test@example.org',
+            'password': u'testpass',
+            'name': 'Test User',
+            'honor_code': 'true',
+            'terms_of_service': 'true',
+            'registration_number': self.username,
+            'current_level': 1,
+            'programme': 2,
+            'department': 1,
+            'other_name': 'tester',
+            'mobile_number': '090078601'
+        }
+
+    def test_create_user_with_all_required_valid_fields(self):
+        response = self.client.post(self.url, self.params)
+        self.assertEqual(response.status_code, 200)
+
+        user = User.objects.get(username=self.username)
+        edx_user_profile = UserProfile.objects.get(user=user)
+        qverse_user_profile = QVerseUserProfile.objects.get(user=user)
+
+        self.assertEqual(edx_user_profile.name, self.params['name'])
+        self.assertEqual(qverse_user_profile.registration_number, self.params['registration_number'].upper())
+        self.assertEqual(qverse_user_profile.current_level, self.params['current_level'])
+        self.assertEqual(qverse_user_profile.programme, self.params['programme'])
+        self.assertEqual(qverse_user_profile.department.number, self.params['department'])
+        self.assertEqual(qverse_user_profile.other_name, self.params['other_name'])
+        self.assertEqual(qverse_user_profile.mobile_number, self.params['mobile_number'])
+
+    @data(
+        {'current_level': 0, 'programme': 2, 'department': 1},
+        {'current_level': MAX_LEVEL_CHOICES+1, 'programme': 2, 'department': 1},
+        {'current_level': 1, 'programme': 0, 'department': 1},
+        {'current_level': 1, 'programme': MAX_PROGRAMME_CHOICES+1, 'department': 1},
+        {'current_level': 1, 'programme': 2, 'department': 3},
+    )
+    def test_create_user_with_invalid_fields(self, invalid_params):
+        self.params.update(invalid_params)
+        response = self.client.post(self.url, self.params)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(User.objects.all().count(), 0)
+        self.assertEqual(UserProfile.objects.all().count(), 0)
+        self.assertEqual(QVerseUserProfile.objects.all().count(), 0)

--- a/openedx/features/qverse_features/registration/tests/test_tasks.py
+++ b/openedx/features/qverse_features/registration/tests/test_tasks.py
@@ -1,0 +1,24 @@
+"""
+Tests for QVerse registration app tasks.
+"""
+import mock
+
+from django.test import TestCase
+
+from openedx.features.qverse_features.registration.tasks import send_bulk_mail_to_newly_created_students
+from student.tests.factories import UserFactory
+
+
+class RegistrationTasksTests(TestCase):
+    """
+    Tests for registration tasks.
+    """
+    @mock.patch(
+        'openedx.features.qverse_features.registration.tasks.ace.send',
+        autospec=True
+    )
+    def test_send_bulk_mail_to_newly_created_students(self, mocked_mail):
+        student_count = 4
+        new_students = [{'regno': UserFactory().username} for i in range(1, student_count+1)]
+        send_bulk_mail_to_newly_created_students(new_students, 1)
+        self.assertEqual(mocked_mail.call_count, student_count)

--- a/openedx/features/qverse_features/registration/tests/test_validators.py
+++ b/openedx/features/qverse_features/registration/tests/test_validators.py
@@ -1,0 +1,71 @@
+"""
+Tests for QVerse registration models validators.
+"""
+from ddt import ddt, data
+import os
+
+from django.core.exceptions import ValidationError
+from django.test import SimpleTestCase
+
+from openedx.features.qverse_features.registration.models import MAX_LEVEL_CHOICES, MAX_PROGRAMME_CHOICES
+from openedx.features.qverse_features.registration.validators import (validate_admission_file,
+                                                                      validate_current_level,
+                                                                      validate_programme_choices)
+
+
+@ddt
+class RegistrationValidatorsTests(SimpleTestCase):
+    """
+    Tests for registration validators.
+    """
+    def test_registration_admission_file_having_valid_data(self):
+        validation_error_raised = False
+        file_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'fixtures/admission_file.csv')
+        with open(file_path, 'r') as admission_file:
+            try:
+                validate_admission_file(admission_file)
+            except ValidationError:
+                validation_error_raised = True
+
+        self.assertFalse(validation_error_raised)
+
+    def test_registration_admission_file_having_invalid_data(self):
+        file_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'fixtures/invalid_admission_file.csv')
+        with open(file_path, 'r') as invalid_admission_file:
+            self.assertRaises(ValidationError, validate_admission_file, invalid_admission_file)
+
+    @data(
+        1, MAX_LEVEL_CHOICES
+    )
+    def test_validate_current_level_with_valid_values(self, current_level):
+        validation_error_raised = False
+        try:
+            validate_current_level(current_level)
+        except ValidationError:
+            validation_error_raised = True
+
+        self.assertFalse(validation_error_raised)
+
+    @data(
+        0, MAX_LEVEL_CHOICES + 1
+    )
+    def test_validate_current_level_with_invalid_values(self, current_level):
+        self.assertRaises(ValidationError, validate_current_level, current_level)
+
+    @data(
+        1, MAX_PROGRAMME_CHOICES
+    )
+    def test_validate_programme_choices_with_valid_values(self, programme_choice):
+        validation_error_raised = False
+        try:
+            validate_programme_choices(programme_choice)
+        except ValidationError:
+            validation_error_raised = True
+
+        self.assertFalse(validation_error_raised)
+
+    @data(
+        0, MAX_PROGRAMME_CHOICES + 1
+    )
+    def test_validate_programme_choices_with_invalid_values(self, programme_choice):
+        self.assertRaises(ValidationError, validate_programme_choices, programme_choice)


### PR DESCRIPTION
This PR is related to [https://edlyio.atlassian.net/browse/EDE-332](https://edlyio.atlassian.net/browse/EDE-332)

This PR mainly focuses on **Unit Tests for QVerse Registration app** and a minor fix of saving registration number into db in the upper case. 

###### To Run Tests Locally
1. Fetch this branch locally
2. Run the following command in `lms-shell`
```
paver test_system -t openedx/features/qverse_features/registration/
```