### PR TITLE
Set default value of password for output file row for updated user

### DIFF
--- a/openedx/features/qverse_features/registration/signals.py
+++ b/openedx/features/qverse_features/registration/signals.py
@@ -111,6 +111,7 @@ def _create_or_update_edx_user(user_info):
         edx_user.save()
         LOGGER.info('{} user has been created.'.format(edx_user.username))
     else:
+        user_info['password'] = 'N/A'
         LOGGER.info('{} user has been updated.'.format(edx_user.username))
     return edx_user
 


### PR DESCRIPTION
This PR is related to [https://edlyio.atlassian.net/browse/EDE-363](https://edlyio.atlassian.net/browse/EDE-363)

**Description**
When we upload an admission file that has data in such order that the upper rows contain the students' data that already exist and the last one contains the student data which is a new one then we get an error that the password field doesn't exist. To get rid of that error we are using default value of password for updated users.