### PR TITLE
Update unit tests of registration app

### DIFF
--- a/openedx/features/qverse_features/registration/tests/factories.py
+++ b/openedx/features/qverse_features/registration/tests/factories.py
@@ -5,7 +5,7 @@ import factory
 import factory.fuzzy
 import string
 
-from openedx.features.qverse_features.registration.models import (Department, QVerseUserProfile,
+from openedx.features.qverse_features.registration.models import (Department, QVerseUserProfile, ProspectiveUser,
                                                                   MAX_LEVEL_CHOICES, MAX_PROGRAMME_CHOICES)
 from student.tests.factories import UserFactory
 
@@ -34,6 +34,25 @@ class QVerseUserProfileFactory(factory.django.DjangoModelFactory):
     department = factory.SubFactory(DepartmentFactory)
     registration_number = factory.LazyAttribute(u'{0.user.username}'.format)
     other_name = factory.Sequence(u'robot-{0}'.format)
+    mobile_number = factory.fuzzy.FuzzyText(length=11, chars=string.digits)
+    current_level = factory.fuzzy.FuzzyInteger(1, MAX_LEVEL_CHOICES)
+    programme = factory.fuzzy.FuzzyInteger(1, MAX_PROGRAMME_CHOICES)
+
+
+class ProspectiveUserFactory(factory.django.DjangoModelFactory):
+    """
+    Creates ProspectiveUser.
+    """
+    class Meta(object):
+        model = ProspectiveUser
+        django_get_or_create = ('registration_number', )
+
+    registration_number = factory.Sequence(u'{0}'.format)
+    email = factory.Sequence(u'robot+test+{0}@edx.org'.format)
+    department = factory.SubFactory(DepartmentFactory)
+    first_name = factory.Sequence(u'robot-first-name-{0}'.format)
+    surname = factory.Sequence(u'robot-surname-{0}'.format)
+    other_name = factory.Sequence(u'robot-other-name-{0}'.format)
     mobile_number = factory.fuzzy.FuzzyText(length=11, chars=string.digits)
     current_level = factory.fuzzy.FuzzyInteger(1, MAX_LEVEL_CHOICES)
     programme = factory.fuzzy.FuzzyInteger(1, MAX_PROGRAMME_CHOICES)

--- a/openedx/features/qverse_features/registration/tests/test_forms.py
+++ b/openedx/features/qverse_features/registration/tests/test_forms.py
@@ -1,0 +1,41 @@
+"""
+Unit tests QVerse registration app forms.
+"""
+from ddt import ddt, data, unpack
+
+from django.test import SimpleTestCase
+
+from openedx.features.qverse_features.registration.forms import QVerseUserProfileForm
+
+
+@ddt
+class QVerseUserProfileFormTests(SimpleTestCase):
+
+    def setUp(self):
+        self.form = QVerseUserProfileForm()
+
+    @data(
+        ('first_name', 'Enter your first name.'),
+        ('surname', 'Enter your surname.'),
+        ('registration_number', 'Enter your registration number provided from your school.'),
+        ('other_name', 'Enter your nick name.'),
+        ('mobile_number', 'Enter your mobile number.'),
+        ('current_level', 'Select your current level in school during admission.'),
+        ('programme', 'Select the programme that you have been enrolled in.'),
+        ('department', 'Select your department.')
+    )
+    @unpack
+    def test_form_help_texts(self, field_name, help_text):
+        self.assertEqual(self.form.fields[field_name].help_text, help_text)
+
+    @data(
+        ('first_name', 'Please enter your First Name.'),
+        ('surname', 'Please enter your Surname.'),
+        ('registration_number', 'Please enter your Registration Number.'),
+        ('current_level', 'Please select a valid Current Level.'),
+        ('programme', 'Please select the valid Programme that you have been enrolled in.'),
+        ('department', 'Please select a valid Department'),
+    )
+    @unpack
+    def test_form_error_messages_for_required_fields(self, field_name, error_message):
+        self.assertEqual(self.form.fields[field_name].error_messages['required'], error_message)

--- a/openedx/features/qverse_features/registration/tests/test_register.py
+++ b/openedx/features/qverse_features/registration/tests/test_register.py
@@ -1,7 +1,7 @@
 """
 Tests for account creation.
 """
-from ddt import ddt, data
+from ddt import ddt, data, unpack
 
 from django.conf import settings
 from django.contrib.auth.models import User
@@ -9,10 +9,8 @@ from django.test import TestCase
 from django.test.utils import override_settings
 from django.urls import reverse
 
-from openedx.features.qverse_features.registration.models import (QVerseUserProfile,
-                                                                  MAX_LEVEL_CHOICES,
-                                                                  MAX_PROGRAMME_CHOICES)
-from openedx.features.qverse_features.registration.tests.factories import DepartmentFactory
+from openedx.features.qverse_features.registration.models import QVerseUserProfile, ProspectiveUser
+from openedx.features.qverse_features.registration.tests.factories import DepartmentFactory, ProspectiveUserFactory
 
 from student.models import UserProfile
 
@@ -31,51 +29,64 @@ class CreateAccountTests(TestCase):
     """
     def setUp(self):
         super(CreateAccountTests, self).setUp()
-        DepartmentFactory(number=1)
-        self.username = 'test_user'
+        self.department = DepartmentFactory(__sequence=1)
+        self.prospective_user = ProspectiveUserFactory(department=self.department, current_level=1, programme=1)
+
         self.url = reverse('create_account')
         self.params = {
-            'username': self.username,
-            'email': 'test@example.org',
+            'username': 'test_user',
+            'email': self.prospective_user.email,
             'password': u'testpass',
-            'name': 'Test User',
+            'first_name': self.prospective_user.first_name,
+            'surname': self.prospective_user.surname,
             'honor_code': 'true',
             'terms_of_service': 'true',
-            'registration_number': self.username,
-            'current_level': 1,
-            'programme': 2,
-            'department': 1,
-            'other_name': 'tester',
-            'mobile_number': '090078601'
+            'registration_number': self.prospective_user.registration_number,
+            'current_level': self.prospective_user.current_level,
+            'programme': self.prospective_user.programme,
+            'department': self.prospective_user.department.number,
+            'other_name': self.prospective_user.other_name,
+            'mobile_number': self.prospective_user.mobile_number
         }
 
     def test_create_user_with_all_required_valid_fields(self):
         response = self.client.post(self.url, self.params)
         self.assertEqual(response.status_code, 200)
 
-        user = User.objects.get(username=self.username)
+        user = User.objects.get(username=self.params['username'])
         edx_user_profile = UserProfile.objects.get(user=user)
         qverse_user_profile = QVerseUserProfile.objects.get(user=user)
 
-        self.assertEqual(edx_user_profile.name, self.params['name'])
+        name = '{} {}'.format(self.prospective_user.first_name, self.prospective_user.surname)
+        self.assertEqual(edx_user_profile.name, name)
         self.assertEqual(qverse_user_profile.registration_number, self.params['registration_number'].upper())
         self.assertEqual(qverse_user_profile.current_level, self.params['current_level'])
         self.assertEqual(qverse_user_profile.programme, self.params['programme'])
         self.assertEqual(qverse_user_profile.department.number, self.params['department'])
         self.assertEqual(qverse_user_profile.other_name, self.params['other_name'])
         self.assertEqual(qverse_user_profile.mobile_number, self.params['mobile_number'])
+        self.assertEqual(ProspectiveUser.objects.all().count(), 0)
 
     @data(
-        {'current_level': 0, 'programme': 2, 'department': 1},
-        {'current_level': MAX_LEVEL_CHOICES+1, 'programme': 2, 'department': 1},
-        {'current_level': 1, 'programme': 0, 'department': 1},
-        {'current_level': 1, 'programme': MAX_PROGRAMME_CHOICES+1, 'department': 1},
-        {'current_level': 1, 'programme': 2, 'department': 3},
+        ({'registration_number': 'DEMO123'}, 'You are not authorized to register.'),
+        ({'programme': 2}, 'Your programme doesn\'t match with the programme included in the admission data.'),
+        ({'programme': 2}, 'Your programme doesn\'t match with the programme included in the admission data.'),
+        ({'first_name': 1}, 'Your first name doesn\'t match with the first name included in the admission data.'),
+        ({'surname': 1}, 'Your surname doesn\'t match with the surname included in the admission data.'),
+        ({'current_level': 2}, ('Your current level doesn\'t match with the '
+                                'current level included in the admission data.')),
     )
-    def test_create_user_with_invalid_fields(self, invalid_params):
+    @unpack
+    def test_create_user_with_invalid_unmatched_data_for_required_fields(self, invalid_params, error_message):
+        """
+        Test that if the required registration data doesn't match
+        with the data stored for prospective users, an appropriate
+        message should be sent.
+        """
         self.params.update(invalid_params)
         response = self.client.post(self.url, self.params)
         self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()['value'], error_message)
         self.assertEqual(User.objects.all().count(), 0)
         self.assertEqual(UserProfile.objects.all().count(), 0)
         self.assertEqual(QVerseUserProfile.objects.all().count(), 0)


### PR DESCRIPTION
This PR is related to [https://edlyio.atlassian.net/browse/EDE-400](https://edlyio.atlassian.net/browse/EDE-400)

**PR Description**
In this PR the unit tests of the registration app for qverse have been updated according to the updated user registration flow.

**How to test:**
1. Fetch this branch to local
3. Run the following command to run tests
```
paver test_system -t openedx/features/qverse_features/registration/tests/ --fasttest
```
![image](https://user-images.githubusercontent.com/42294172/79944319-a5c63000-8484-11ea-87fc-bfe8e8ba1d1d.png)
