### PR TITLE
EDE-447 Add one time password feature

### DIFF
--- a/openedx/features/qverse_features/registration/templates/registration/edx_ace/registrationnotification/email/body.html
+++ b/openedx/features/qverse_features/registration/templates/registration/edx_ace/registrationnotification/email/body.html
@@ -15,15 +15,9 @@
 
             <p style="color: rgba(0,0,0,.75);">
                 {% blocktrans %}
-                    You have been registered successfully on {{ site_name }}.
+                    You have been successfully registered on {{ site_name }} with the following credentials:
                 {% endblocktrans %}
                 <br />
-            </p>
-
-            <p style="color: rgba(0,0,0,.75);">
-                {% blocktrans %}
-                    This is your login information:
-                {% endblocktrans %}
             </p>
 
             <p style="color: rgba(0,0,0,.75);">
@@ -32,18 +26,11 @@
                 <br />
                 <b>{% blocktrans %}Email:{% endblocktrans %}</b>
                 {% blocktrans %}{{ email }}{% endblocktrans %}
-                <br />
-                <b>{% blocktrans %}Password:{% endblocktrans %}</b>
-                {% blocktrans %}{{ password }}{% endblocktrans %}
             </p>
 
             <p style="color: rgba(0,0,0,.75);">
-                {% blocktrans %}A random password has been set for your account. You should change it after login.{% endblocktrans %}
-            </p>
-
-            <p style="color: rgba(0,0,0,.75);">
-                {% blocktrans %} Click here to login: {% endblocktrans %}
-                <a class="login" href="{% with_link_tracking dashboard_url %}" style="color: #005686;">{% with_link_tracking dashboard_url %}</a>
+                <b>{% blocktrans %}Click on the link below to set your account password:{% endblocktrans %}</b>
+                <a class="login" href="{{ reset_password_link }}" style="color: #005686;">{{ reset_password_link }}</a>
             </p>
 
             <p style="color: rgba(0,0,0,.75);">

--- a/openedx/features/qverse_features/registration/templates/registration/edx_ace/registrationnotification/email/body.txt
+++ b/openedx/features/qverse_features/registration/templates/registration/edx_ace/registrationnotification/email/body.txt
@@ -1,16 +1,16 @@
 {% load i18n %}{% autoescape off %}{% blocktrans %}Dear {{ firstname }},{% endblocktrans %}
 
 
-{% blocktrans %}You have been registered successfully on {{ site_name }}.{% endblocktrans %}
+{% blocktrans %}You have been successfully registered on {{ site_name }} with the following credentials:{% endblocktrans %}
 
 
-{% blocktrans %}This is your login information:{% endblocktrans %}
 
 {% blocktrans %}Registration Number (username): {{ regno }}{% endblocktrans %}
 {% blocktrans %}Email: {{ email }}{% endblocktrans %}
-{% blocktrans %}Password: {{ password }}{% endblocktrans %}
 
+{% blocktrans %}Click on the link below to set your account password:{% endblocktrans %}
 
+{{ reset_password_link }}
 ----
 {% blocktrans %}Thanks,{% endblocktrans %}
 {% blocktrans %}{{ platform_name }}{% endblocktrans %}


### PR DESCRIPTION
This PR is related to
[EDE-447](https://edlyio.atlassian.net/browse/EDE-447)

**PR description**
The client requirement is, that after uploading the admission file, new users should be created and their login credentials should be sent in an email to them, which includes the ONE TIME PASSWORD **which will be used to set the new password**. Here, the main purpose of OTP is to force the user to set his own password by himself.

If we try to implement this requirement as it is, we need to do some major changes in edx-platform.

As the main thing in this requirement is to force the user to set his password, so, instead of providing OTP in email, we are providing a password reset link to the user. 

We are not providing any password in the email, just a reset password link which will be expired just after its first time usage. In this way, the user is forced to set his account password.

**Email Content**
![image](https://user-images.githubusercontent.com/42294172/81641194-dc66e900-9439-11ea-8fb4-8312b9c434c8.png)

**Reset Password Page**
![image](https://user-images.githubusercontent.com/42294172/81641237-f56f9a00-9439-11ea-9bcc-5e3133dec5e4.png)

**Reset Password Page After Expiry**
![image](https://user-images.githubusercontent.com/42294172/81641280-11733b80-943a-11ea-9de7-cb4b068f54c2.png)

