### PR TITLE
EDE-500 Use different passwords timeouts for otp link and reset password link

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1427,6 +1427,9 @@ XBLOCK_SETTINGS = {
 
 STUDIO_FRONTEND_CONTAINER_URL = None
 
+############## Settings for QVerse registration app ##############
+OTP_LINK_TIMEOUT = 60 # Shows number of days and it's minimum value can be 1 day
+
 ################################ Settings for Credit Course Requirements ################################
 # Initial delay used for retrying tasks.
 # Additional retries use longer delays.

--- a/cms/envs/production.py
+++ b/cms/envs/production.py
@@ -577,6 +577,10 @@ COMPLETION_VIDEO_COMPLETE_PERCENTAGE = ENV_TOKENS.get(
     COMPLETION_VIDEO_COMPLETE_PERCENTAGE,
 )
 
+
+############## Settings for QVerse registration app ##############
+OTP_LINK_TIMEOUT = ENV_TOKENS.get('OTP_LINK_TIMEOUT', OTP_LINK_TIMEOUT)
+
 ####################### Enterprise Settings ######################
 # A shared secret to be used for encrypting passwords passed from the enterprise api
 # to the enteprise reporting script.

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2593,6 +2593,9 @@ REGISTRATION_EMAIL_PATTERNS_ALLOWED = None
 CERT_NAME_SHORT = "Certificate"
 CERT_NAME_LONG = "Certificate of Achievement"
 
+############## Settings for QVerse registration app ##############
+OTP_LINK_TIMEOUT = 60 # # Shows number of days and it's minimum value can be 1 day
+
 #################### OpenBadges Settings #######################
 
 BADGING_BACKEND = 'badges.backends.badgr.BadgrBackend'

--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -1069,6 +1069,9 @@ PARENTAL_CONSENT_AGE_LIMIT = ENV_TOKENS.get(
 # Do NOT calculate this dynamically at startup with git because it's *slow*.
 EDX_PLATFORM_REVISION = ENV_TOKENS.get('EDX_PLATFORM_REVISION', EDX_PLATFORM_REVISION)
 
+############## Settings for QVerse registration app ##################
+OTP_LINK_TIMEOUT = ENV_TOKENS.get('OTP_LINK_TIMEOUT', OTP_LINK_TIMEOUT)
+
 ########################## Extra middleware classes  #######################
 
 # Allow extra middleware classes to be added to the app through configuration.

--- a/openedx/features/qverse_features/registration/context_manager.py
+++ b/openedx/features/qverse_features/registration/context_manager.py
@@ -1,0 +1,28 @@
+"""
+Contains context managers of QVerse registration app.
+"""
+from django.conf import settings
+
+
+class one_time_password_link_expiry:
+    """
+    It's a context manager, responsible to set different expiry durations
+    for reset password link and one time password link.
+    """
+    def __init__(self, **kwargs):
+        self.last_login = kwargs['last_login']
+        self.default_timeout = kwargs['default_timeout']
+
+    def __enter__(self):
+        """
+        If user have never logged in to the system, we will change
+        the expiry duration of reset password link.
+        """
+        if not self.last_login:
+            settings.PASSWORD_RESET_TIMEOUT_DAYS = settings.OTP_LINK_TIMEOUT
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        """
+        Revert to the original settings.
+        """
+        settings.PASSWORD_RESET_TIMEOUT_DAYS = self.default_timeout

--- a/openedx/features/qverse_features/registration/models.py
+++ b/openedx/features/qverse_features/registration/models.py
@@ -37,6 +37,7 @@ REGISTRATION_NUMBER_MAX_LENGTH = 30
 OTHER_NAME_MAX_LENGTH = 50
 MOBILE_NUMBER_MAX_LENGTH = 20
 
+
 class BulkUserRegistration(models.Model):
     """
     Saves csv records for bulk user registration.

--- a/openedx/features/qverse_features/registration/signals.py
+++ b/openedx/features/qverse_features/registration/signals.py
@@ -266,7 +266,10 @@ class CsvRowValidator(object):
         OPTIONAL_FIELDS = [
             'mobile', 'othername', 'status', 'error'
         ]
-        required_values = [value.strip() if value else value for (key, value) in row.items() if key not in OPTIONAL_FIELDS]
+        required_values = [value.strip()
+                           if value else value
+                           for (key, value) in row.items()
+                           if key not in OPTIONAL_FIELDS]
         all_values_available = all(required_values)
 
         if not all_values_available:
@@ -336,7 +339,8 @@ class CsvRowValidator(object):
 
     def _validate_registration_number(self):
         if len(self.regno) > REGISTRATION_NUMBER_MAX_LENGTH:
-            self.errors.append('Registration number is more than {} characters long.'.format(REGISTRATION_NUMBER_MAX_LENGTH))
+            self.errors.append(('Registration number is more '
+                                'than {} characters long.').format(REGISTRATION_NUMBER_MAX_LENGTH))
 
         if not self.regno.isalnum():
             self.errors.append('Please provide some valid alpha numeric value for registration number.')
@@ -370,7 +374,8 @@ class CsvRowValidator(object):
         try:
             programme_id = int(self.programme_id)
             if programme_id < 1 or programme_id > MAX_PROGRAMME_CHOICES:
-                self.errors.append('Programme ID must be greater than 0 and smaller than {}.'.format(MAX_PROGRAMME_CHOICES+1))
+                self.errors.append(('Programme ID must be greater '
+                                    'than 0 and smaller than {}.').format(MAX_PROGRAMME_CHOICES+1))
         except ValueError:
             self.errors.append('Programme ID is not an integer value.')
 


### PR DESCRIPTION
This PR is related to [EDE-500](https://edlyio.atlassian.net/browse/EDE-500)

**PR description**
We are sending the one-time password link to the user through email after the very registration process by uploading the CSV admission file.
That link is using the same functionality that Django uses for reset password link.

To control the expiry duration of reset password link Django uses a setting named `PASSWORD_RESET_TIMEOUT_DAYS` whose value is set in integers which shows the number of days.
Its default value is 3 Days

The same setting applies to a one-time password link. It means that our one-time password link will be expired after 3 days which is not required.

So now, in order to set different expiry durations for these two types of reset password links, we have written a context manager that we are using in this PR.