### PR TITLE
EDE-529 Revert to old registration form

### DIFF
--- a/openedx/core/djangoapps/user_api/api.py
+++ b/openedx/core/djangoapps/user_api/api.py
@@ -213,9 +213,8 @@ def _apply_third_party_auth_overrides(request, form_desc):
 
 class RegistrationFormFactory(object):
     """HTTP end-points for creating a new user. """
-    # To remove full name field from the registration form shown to the user
-    # the "name" field has been removed from DEFAULT_FIELDS
-    DEFAULT_FIELDS = ["email", "username", "password"]
+
+    DEFAULT_FIELDS = ["email", "name", "username", "password"]
 
     EXTRA_FIELDS = [
         "confirm_email",

--- a/openedx/core/djangoapps/user_authn/views/register.py
+++ b/openedx/core/djangoapps/user_authn/views/register.py
@@ -146,8 +146,6 @@ def create_account_with_params(request, params):
         not do_external_auth or
         not eamap.external_domain.startswith(settings.SHIBBOLETH_DOMAIN_PREFIX)
     )
-    if 'first_name' in params.keys() and 'surname' in params.keys():
-        params['name'] = '{} {}'.format(params['first_name'], params['surname'])
     form = AccountCreationForm(
         data=params,
         extra_fields=extra_fields,


### PR DESCRIPTION
This PR is related to [https://edlyio.atlassian.net/browse/EDE-529](https://edlyio.atlassian.net/browse/EDE-529)

**PR Description**
In this PR we are reverting to the original form of `registration form` as it is in `edx`. Later if the client demands, we will remove normal registration. 


Previously, we removed `full name` field from the `registration form` and added some custom fields like `first name`, `surname` etc. Using these fields we were setting the `full name` by ourselves. Now, as we are reverting to original `registration flow` so just removing that part.

We will also remove `REGISTRATION_EXTENSION_FORM` settings from `lms.env.json`


The code that we are removing in this PR, was added in this PR [https://github.com/q-verse/edx-platform/pull/1](https://github.com/q-verse/edx-platform/pull/1)