### PR TITLE
EDE-559 Block invalid file encoding formats

### DIFF
--- a/openedx/features/qverse_features/registration/helpers.py
+++ b/openedx/features/qverse_features/registration/helpers.py
@@ -42,10 +42,16 @@ def get_file_encoding(file_path):
         file = io.open(file_path, 'r', encoding='utf-8')
         encoding = None
         try:
-            encoding = 'utf-8'
             _ = file.read()
+            encoding = 'utf-8'
         except UnicodeDecodeError:
-            encoding = 'utf-16'
+            file.close()
+            file = io.open(file_path, 'r', encoding='utf-16')
+            try:
+                _ = file.read()
+                encoding = 'utf-16'
+            except UnicodeDecodeError:
+                LOGGER.exception('The file encoding format must be utf-8 or utf-16.')
 
         file.close()
         return encoding

--- a/openedx/features/qverse_features/registration/signals.py
+++ b/openedx/features/qverse_features/registration/signals.py
@@ -54,6 +54,10 @@ def create_users_from_csv_file(sender, instance, created, **kwargs):
     dialect = None
     try:
         encoding = get_file_encoding(instance.admission_file.path)
+        if not encoding:
+            LOGGER.exception('Because of invlid file encoding format, user creation process is aborted.')
+            return
+
         csv_file = io.open(instance.admission_file.path, 'r', encoding=encoding)
         try:
             dialect = Sniffer().sniff(csv_file.readline())


### PR DESCRIPTION
This PR is related to [https://edlyio.atlassian.net/browse/EDE-559](https://edlyio.atlassian.net/browse/EDE-559)

**PR Description**
In this [PR 31](https://github.com/q-verse/edx-platform/pull/31), we did a mistake. We were not checking that what will happen if the file encoding format didn't match with utf-8 and utf-16 encoding format. In this case, our server was crashed. This issue has been fixed in this PR
